### PR TITLE
Update KDRS XML generation to use Search & View 1.5 syntax

### DIFF
--- a/database.py
+++ b/database.py
@@ -907,13 +907,10 @@ class Database:
         return ddl
 
     def export_as_kdrs_xml(self, version, descr):
-        xml = "<root>\n"
-        xml += "  <meta>\n"
-        xml += "    <version>" + version + "</version>\n"
-        xml += "    <description>" + descr + "</description>\n"
-        xml += "  </meta>\n"
-        xml += "  <views>\n"
-
+        xml = "<views>\n"
+        xml += "  <version>" + version + "</version>\n"
+        xml += "  <description>" + descr + "</description>\n"
+        
         self.get_tables()
         contents = self.get_contents()
 
@@ -930,16 +927,15 @@ class Database:
                 table = Table(self, tbl_name)
                 tbl.fields = table.fields
 
-            xml += "    <view>\n"
-            xml += "      <name>" + tbl.label + "</name>\n"
-            xml += "      <tables>\n"
-            xml += "        <table>\n"
-            xml += "          <name>" + tbl.name + "</name>\n"
-            xml += "          <heading>Finn " + tbl.label + "</heading>\n"
-            xml += "          <fields>" + ', '.join(tbl.fields.keys()) + "</fields>\n"
-            xml += "          <primarykey>" + ', '.join(tbl.pkey.columns) + "</primarykey>\n"
-            xml += "          <preview>false</preview>\n"  # TODO: how to choose value?
-            xml += "        </table>\n"
+            xml += "  <view>\n"
+            xml += "    <name>" + tbl.label + "</name>\n"
+            xml += "    <table>\n"
+            xml += "      <name>" + tbl.name + "</name>\n"
+            xml += "      <heading>Finn " + tbl.label + "</heading>\n"
+            xml += "      <fields>" + ', '.join(tbl.fields.keys()) + "</fields>\n"
+            xml += "      <primarykey>" + ', '.join(tbl.pkey.columns) + "</primarykey>\n"
+            xml += "      <preview>false</preview>\n"  # TODO: how to choose value?
+            xml += "    </table>\n"
 
             if 'subitems' in obj:
                 for subitem, subobj in obj.subitems.items():
@@ -960,34 +956,31 @@ class Database:
                         if fkey.referred_table == tbl.name:
                             fkey_str = ', '.join(fkey.constrained_columns)
 
-                    xml += "        <table>\n"
-                    xml += "          <name>" + subtbl.name + "</name>\n"
-                    xml += "          <heading>" + subtbl.label + "</heading>\n"
-                    xml += "          <parent>" + tbl.name + "</parent>\n"
-                    xml += "          <fields>" + ', '.join(subtbl.fields.keys()) + "</fields>\n"
-                    xml += "          <primarykey>" + ', '.join(subtbl.pkey.columns) + "</primarykey>\n"
-                    xml += "          <foreignkey>" + fkey_str + "</foreignkey>\n"
-                    xml += "          <search>true</search>\n"  # TODO: how to choose value?
+                    xml += "    <table>\n"
+                    xml += "      <name>" + subtbl.name + "</name>\n"
+                    xml += "      <heading>" + subtbl.label + "</heading>\n"
+                    xml += "      <parent>" + tbl.name + "</parent>\n"
+                    xml += "      <fields>" + ', '.join(subtbl.fields.keys()) + "</fields>\n"
+                    xml += "      <primarykey>" + ', '.join(subtbl.pkey.columns) + "</primarykey>\n"
+                    xml += "      <foreignkey>" + fkey_str + "</foreignkey>\n"
+                    xml += "      <search>true</search>\n"  # TODO: how to choose value?
                     if subtbl.grid and 'sort_columns' in subtbl.grid:
-                        xml += "          <sort>" + ', '.join(subtbl.grid.sort_columns) + "</sort>\n"
+                        xml += "      <sort>" + ', '.join(subtbl.grid.sort_columns) + "</sort>\n"
 
                     for key, fkey in subtbl.fkeys.items():
                         last_col = fkey.constrained_columns[-1]
                         view = subtbl.fields[last_col].view
                         view = view.replace(last_col + '.', '')
-                        xml += "          <lookup>\n"
-                        xml += "            <foreignkey>" + ', '.join(fkey.constrained_columns) + "</foreignkey>\n"
-                        xml += "            <table>" + fkey.referred_table + "</table>\n"
-                        xml += "            <primarykey>" + ', '.join(fkey.referred_columns) + "</primarykey>\n"
-                        xml += "            <fields>" + view + ' as ' + last_col + "</fields>\n"
-                        xml += "          </lookup>\n"
+                        xml += "      <lookup>\n"
+                        xml += "        <foreignkey>" + ', '.join(fkey.constrained_columns) + "</foreignkey>\n"
+                        xml += "        <table>" + fkey.referred_table + "</table>\n"
+                        xml += "        <primarykey>" + ', '.join(fkey.referred_columns) + "</primarykey>\n"
+                        xml += "        <fields>" + view + ' as ' + last_col + "</fields>\n"
+                        xml += "      </lookup>\n"
 
-                    xml += "        </table>\n"
+                    xml += "    </table>\n"
 
-            xml += "      </tables>\n"
-            xml += "    </view>\n"
-
-        xml += "  </views\n>"
-        xml += "</root>"
+            xml += "  </view>\n"
+        xml += "</views>"
 
         return xml


### PR DESCRIPTION
KDRS Search & View 1.5 comes with some changes to the XML syntax that are documented here: https://kdrs-sa.github.io/kdrs-search-and-view-docs/develop/1.5/xml/views/ (this documentation is WIP until release)

The important changes are
- Tag 'root' is removed, 'views' is now root element.
- Tag 'tables' is removed, 'table' elements go directly inside a 'view'
- Tag 'metadata' is removed, 'version' and 'description' go inside 'views'

I have implemented this new syntax in the export_as_kdrs_xml function. Unfortunately, I was unable to connect to my SQL db and test my changes, therefore it would be nice if someone could generate some XML with these changes so I can verify that they are correct.

Lastly, this change should probably not be merged until Search & View 1.5 is actually released, which is expected to be before the end of the month.